### PR TITLE
Fix an issue with working with gpu

### DIFF
--- a/mobile_sam/modeling/tiny_vit_sam.py
+++ b/mobile_sam/modeling/tiny_vit_sam.py
@@ -253,7 +253,9 @@ class Attention(torch.nn.Module):
         if mode and hasattr(self, 'ab'):
             del self.ab
         else:
-            self.ab = self.attention_biases[:, self.attention_bias_idxs]
+            self.register_buffer('ab',
+                                 self.attention_biases[:, self.attention_bias_idxs],
+                                 persistent=False)
 
     def forward(self, x):  # x (B,N,C)
         B, N, _ = x.shape


### PR DESCRIPTION
The variable `ab` needs to be registered to buffer to avoid an error with incompatible devices.

```
  File "/home/user/MobileSAM/mobile_sam/modeling/tiny_vit_sam.py", line 274, in forward
    (q @ k.transpose(-2, -1)) * self.scale
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

https://github.com/ChaoningZhang/MobileSAM/blob/8432fa82001e234c7c3484e1aeee5f00968581de/mobile_sam/modeling/tiny_vit_sam.py#L256

needs to be modified as follows.

```python
    self.register_buffer('ab',
                         self.attention_biases[:, self.attention_bias_idxs],
                         persistent=False)
```