### PR TITLE
fix the gradio demo bug

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -103,6 +103,9 @@ def segment_with_points(
     global global_points
     global global_point_label
 
+    if len(global_points) == 0:
+        return segment_everything(image), image
+
     input_size = int(input_size)
     w, h = image.size
     scale = input_size / max(w, h)


### PR DESCRIPTION
When users do not input reference points and masks, the default behavior is to display the results for the entire image instead of just showing the original image. 