### PR TITLE
Update in_points for MPS compatibility

### DIFF
--- a/mobile_sam/automatic_mask_generator.py
+++ b/mobile_sam/automatic_mask_generator.py
@@ -274,7 +274,7 @@ class SamAutomaticMaskGenerator:
 
         # Run model on this batch
         transformed_points = self.predictor.transform.apply_coords(points, im_size)
-        in_points = torch.as_tensor(transformed_points, device=self.predictor.device)
+        in_points = torch.as_tensor(transformed_points, dtype=torch.float, device=self.predictor.device)
         in_labels = torch.ones(in_points.shape[0], dtype=torch.int, device=in_points.device)
         masks, iou_preds, _ = self.predictor.predict_torch(
             in_points[:, None, :],


### PR DESCRIPTION
Added dtype when converting transformed points to tensor (L277:` in_points = torch.as_tensor(....`) so it converts to the correct dtype based on the device. Specifically, on MPS, it converts to float32 instead of float64, as float64 is not supported on MPS.