### PR TITLE
Add Hugging Face integration

### DIFF
--- a/mobile_sam/build_sam.py
+++ b/mobile_sam/build_sam.py
@@ -70,8 +70,8 @@ def build_sam_vit_t(checkpoint=None):
             mask_in_chans=16,
             ),
             mask_decoder=MaskDecoder(
-                    num_multimask_outputs=3,
-                    transformer=TwoWayTransformer(
+                num_multimask_outputs=3,
+                transformer=TwoWayTransformer(
                     depth=2,
                     embedding_dim=prompt_embed_dim,
                     mlp_dim=2048,

--- a/mobile_sam/modeling/image_encoder.py
+++ b/mobile_sam/modeling/image_encoder.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 
 from typing import Optional, Tuple, Type
 
-from .common import LayerNorm2d, MLPBlock
+from common import LayerNorm2d, MLPBlock
 
 
 # This class and its supporting functions below lightly adapted from the ViTDet backbone available at: https://github.com/facebookresearch/detectron2/blob/main/detectron2/modeling/backbone/vit.py # noqa

--- a/mobile_sam/modeling/mask_decoder.py
+++ b/mobile_sam/modeling/mask_decoder.py
@@ -10,7 +10,7 @@ from torch.nn import functional as F
 
 from typing import List, Tuple, Type
 
-from .common import LayerNorm2d
+from common import LayerNorm2d
 
 
 class MaskDecoder(nn.Module):

--- a/mobile_sam/modeling/prompt_encoder.py
+++ b/mobile_sam/modeling/prompt_encoder.py
@@ -10,7 +10,7 @@ from torch import nn
 
 from typing import Any, Optional, Tuple, Type
 
-from .common import LayerNorm2d
+from common import LayerNorm2d
 
 
 class PromptEncoder(nn.Module):

--- a/mobile_sam/modeling/transformer.py
+++ b/mobile_sam/modeling/transformer.py
@@ -10,7 +10,7 @@ from torch import Tensor, nn
 import math
 from typing import Tuple, Type
 
-from .common import MLPBlock
+from common import MLPBlock
 
 
 class TwoWayTransformer(nn.Module):


### PR DESCRIPTION
Hi @ChaoningZhang @qiaoyu1002 and team!

Thanks for this nice work. I wrote a quick PoC to showcase that you can easily have integration so that you can automatically load the various MobileSAM models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from mobile_sam import MobileSAM

model = MobileSAM.from_pretrained("nielsr/mobilesam")
```
The corresponding model is here for now: https://huggingface.co/nielsr/mobilesam. We could move all checkpoints to separate repos on your account on https://hf.co if you're interested.

Would you be interested in this integration?

Kind regards,

Niels