### PR TITLE
[OPT] Faster the Two-Way Attention Block for CPU/GPU

### DIFF
--- a/mobile_sam/modeling/transformer.py
+++ b/mobile_sam/modeling/transformer.py
@@ -160,9 +160,12 @@ class TwoWayAttentionBlock(nn.Module):
             queries = queries + attn_out
         queries = self.norm1(queries)
 
+        # Compute once and Reuse while `keys` is unchanged.
+        k = keys + key_pe
+
         # Cross attention block, tokens attending to image embedding
         q = queries + query_pe
-        k = keys + key_pe
+        # k = keys + key_pe   # Re-use the `keys` as above. 
         attn_out = self.cross_attn_token_to_image(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm2(queries)
@@ -174,7 +177,7 @@ class TwoWayAttentionBlock(nn.Module):
 
         # Cross attention block, image embedding attending to tokens
         q = queries + query_pe
-        k = keys + key_pe
+        # k = keys + key_pe     # Re-use the `keys` as above. 
         attn_out = self.cross_attn_image_to_token(q=k, k=q, v=queries)
         keys = keys + attn_out
         keys = self.norm4(keys)


### PR DESCRIPTION
## PR: Deduplicate `keys + key_pe` in `TwoWayAttentionBlock`

### Summary: 

Improve the `TwoWayAttentionBlock` by deduplicate the `keys` calculation. 

### Description: 

In the `forward` method in the `transformer.py` file, the `keys` field is being calculated twice for both `queries` path (2 & 3) and `keys` path (4), with four consecutive `forward` call in MobileSAMv1 (tested on the bundled `mobile_sam.pt` file. The improvement is relatively modest, especially over the CPU. 

Since for each image, it would generate an extra tensor of `(N_image, 4096, 256)` which cause some extra performance overhead. 

Improvement:

It is tested by on Windows 11 with Ryzen 7 7435HS CPU and RTX 4060 Laptop (no overclock) with one initial warm-up. The test is to repeatedly call over 100 times over single image to simulate the latency (hopefully seeing an improvement on Linux as well). 

| Environment | Before (seconds) | After (seconds) | 
| -------------- | ------------------ | ----------------- |
| CPU               | 4.8498                 | 4.3273 -> 11%  |
| GPU               | 0.9705                 | 0.8295 -> 15%  |

### Changed Files: 

- `./mobile_sam/modeling/transformer.py`


### Behaviour Changes: NO

### Reproduction Code

**`TwoWayAttentionBlock.forward` — before:**

```python

model_type = "vit_t"
sam_checkpoint = "./weight/mobile_sam.pt"

mobile_sam = sam_model_registry[model_type](checkpoint=sam_checkpoint)
mobile_sam.to(device="cuda" if torch.cuda.is_available() else "cpu")
# mobile_sam.to(device="cpu")
mobile_sam.eval()

predictor = SamPredictor(mobile_sam)
image = cv2.imread('./test_images/3.jpeg')
image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)

predictor.set_image(image)

input_point = np.array([[800, 450]])
input_label = np.array([1])

# Warm-up
_, _, _ = predictor.predict(
    point_coords=input_point,
    point_labels=input_label,
    multimask_output=False,
)

t = perf_counter()
for i in range(100):
    _, _, _ = predictor.predict(
        point_coords=input_point,
        point_labels=input_label,
        multimask_output=False,
    )
print('Execution time: ', perf_counter() - t)

masks, scores, logits = predictor.predict(
    point_coords=input_point,
    point_labels=input_label,
    multimask_output=False,
)
print('Masks Shape:', masks.shape)
print('Scores Shape:', scores.shape)
print('Logits Shape:', logits.shape)
```